### PR TITLE
FIX BUG: cell value out of 0 to 255 range

### DIFF
--- a/ahangarha.py
+++ b/ahangarha.py
@@ -138,21 +138,28 @@ def execute(inputCode=''):
     if (code == ''):
         raise ValueError("ERROR: No BrainFuck character is in the code!")
     
+    # map the inputs to the function blocks
+    operate = {
+       '+' : inc,
+       '-' : dec,
+       '>' : shift_right,
+       '<' : shift_left,
+       '.' : output,
+       '[' : open_loop,
+       ']' : close_loop,
+    }
+    
     while i < len(code):
-        # map the inputs to the function blocks
-        operate = {
-           '+' : inc,
-           '-' : dec,
-           '>' : shift_right,
-           '<' : shift_left,
-           '.' : output,
-           '[' : open_loop,
-           ']' : close_loop,
-        }
-        
         # c as charater
         c = code[i]
         operate[c]()
         i += 1
     
     return(result)
+    
+
+if __name__ == '__main__':
+    result = execute("""
+            ++++++++[>++++++++<-]>+.
+        """)
+    print(result)

--- a/ahangarha.py
+++ b/ahangarha.py
@@ -77,12 +77,16 @@ def open_loop():
                 
             else:
                 inloop = False
+    elif cell[pointer]<0:
+        cell[pointer] = cell[pointer] % 256 # so if cell is -3, it will be translated to 253
+    elif cell[pointer]>255:
+        cell[pointer] = cell[pointer] % 256
 
 # closing loop (])
 def close_loop():
     global cell, pointer, i, code
     
-    if cell[pointer]!=0:
+    if cell[pointer] != 0:
 
         inloop = True
         ignore = 0
@@ -100,6 +104,7 @@ def close_loop():
 
             else:
                 inloop = False
+    
 
 def verify_loop(code):
     code = re.sub('[^[\]]', '', code)

--- a/test_ahangarha.py
+++ b/test_ahangarha.py
@@ -28,6 +28,11 @@ class TestAhangarha(unittest.TestCase):
         
         code = "++[>++++[>++++++++<-]<-]>>+."
         self.assertEqual(ahangarha.execute(code), 'A')
+        
+        # test for cells value out of the range (0,256)
+        code = "++++[->++++++++<]-[----->>++>++<<<]>>+++++++.>-.+++.<+++++.>-------.+++.<<.>>.+.+++.------.+++++++.-----.<<+."
+        self.assertEqual(ahangarha.execute(code), 'mehrad dehbid!')
+
     
     def test_abnormal_input(self):
         code = 'blah' + '+'*65 + '.' + 'blah'


### PR DESCRIPTION
This patch, fixes the problem of setting the value of a cell, out of the
range of (0,256). So, if the cell be set to -1, it gets translated to
255 and if it be set to 256, it gets translated to 0. It can also handle
values less than -1 and more than 256. For example cell value of -3 gets
translated into 253.

There is also one more test included in the test_ahangarha.py which
tests a code which makes a negative cell value.

This hopefully is the last commit in this code :)